### PR TITLE
feat: New XYplot tile SEE-IT, M2S (PT-182567181)

### DIFF
--- a/curriculum/m2s/content.json
+++ b/curriculum/m2s/content.json
@@ -279,6 +279,11 @@
         "isTileTool": true
       },
       {
+        "id": "XYplot",
+        "title": "XY Plot",
+        "isTileTool": true
+      },
+      {
         "id": "undo",
         "title": "Undo",
         "iconId": "icon-undo-tool",

--- a/curriculum/seeit/content.json
+++ b/curriculum/seeit/content.json
@@ -55,8 +55,8 @@
         "isTileTool": true
       },
       {
-        "id": "Geometry",
-        "title": "Graph",
+        "id": "XYplot",
+        "title": "XY Plot",
         "isTileTool": true
       },
       {


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/182567181

Adds the new XYplot tile button to the toolbar in SEE-IT and M2S curriculum units. The change requires the changes made to CLUE in [this PR](https://github.com/concord-consortium/collaborative-learning/pull/1667).