### PR TITLE
only allow one simulator tile

### DIFF
--- a/curriculum/brain/content.json
+++ b/curriculum/brain/content.json
@@ -29,6 +29,9 @@
         },
         "emptyPlotIsNumeric": true,
         "scalePlotOnValueChange": true
+      },
+      "simulator": {
+        "maxTiles": 1
       }
     },
     "learningLog": {


### PR DESCRIPTION
This adds configuration to the `brain` unit so that only one Simulation tile can be created, as described in [PT#185683070](https://www.pivotaltracker.com/story/show/185683070)

- URL parameters, for convenience, are: `&unit=brain&curriculumBranch=only-one-sim-tile-in-brain`
