### PR TITLE
add the numberline control to the example-config-subtabs unit 

### DIFF
--- a/curriculum/example-config-subtabs/content.json
+++ b/curriculum/example-config-subtabs/content.json
@@ -194,7 +194,8 @@
       {"id": "undo", "title": "Undo", "iconId": "icon-undo-tool", "isTileTool": false},
       {"id": "redo", "title": "Redo", "iconId": "icon-redo-tool", "isTileTool": false},
       {"id": "duplicate", "title": "Duplicate", "iconId": "icon-duplicate-tool", "isTileTool": false},
-      {"id": "delete", "title": "Delete", "iconId": "icon-delete-tool", "isTileTool": false}
+      {"id": "delete", "title": "Delete", "iconId": "icon-delete-tool", "isTileTool": false},
+      {"id": "Numberline", "title": "Numberline", "isTileTool": true}
     ],
     "stamps": []
   },


### PR DESCRIPTION
Per Leslie's request so we can access to the 4-up view