### PR TITLE
185466012 Gripper Sim Tile

### DIFF
--- a/curriculum/brain/content.json
+++ b/curriculum/brain/content.json
@@ -33,6 +33,7 @@
         "connectPointsByDefault": true
       },
       "simulator": {
+        "defaultSimulation": "EMG_and_claw",
         "maxTiles": 1
       }
     },

--- a/curriculum/dfe/content.json
+++ b/curriculum/dfe/content.json
@@ -9,7 +9,11 @@
     "settings": {
       "table": {"numFormat": ".2~f"},
       "text": {"tools": ["bold", "subscript", "superscript", "new-variable", "insert-variable", "edit-variable"]},
-      "drawing": {"tools": ["select", "line", "vector", "rectangle", "ellipse", "stamp", "stroke-color", "fill-color", "new-variable", "insert-variable", "edit-variable", "delete"]}
+      "drawing": {"tools": ["select", "line", "vector", "rectangle", "ellipse", "stamp", "stroke-color", "fill-color", "new-variable", "insert-variable", "edit-variable", "delete"]},
+      "simulator": {
+        "defaultSimulation": "EMG_and_claw",
+        "maxTiles": 1
+      }
     },
     "navTabs": {
       "showNavPanel": true,

--- a/curriculum/seeit/content.json
+++ b/curriculum/seeit/content.json
@@ -53,7 +53,7 @@
       },
       {
         "id": "Simulator",
-        "title": "EMG Simulator",
+        "title": "Terrarium Simulator",
         "isTileTool": true
       },
       {

--- a/curriculum/seeit/content.json
+++ b/curriculum/seeit/content.json
@@ -3,7 +3,6 @@
   "abbrevTitle": "SI",
   "title": "See It?",
   "subtitle": "Sensors and Internet of Things",
-  "defaultSimulation": "terrarium",
   "config": {
     "enableHistoryRoles": [
       "teacher"
@@ -25,6 +24,9 @@
         },
         "emptyPlotIsNumeric": true,
         "scalePlotOnValueChange": true
+      },
+      "simulator": {
+        "defaultSimulation": "terrarium"
       }
     },
     "learningLog": {

--- a/curriculum/seeit/content.json
+++ b/curriculum/seeit/content.json
@@ -3,6 +3,7 @@
   "abbrevTitle": "SI",
   "title": "See It?",
   "subtitle": "Sensors and Internet of Things",
+  "defaultSimulation": "terrarium",
   "config": {
     "enableHistoryRoles": [
       "teacher"

--- a/curriculum/seeit/content.json
+++ b/curriculum/seeit/content.json
@@ -51,6 +51,11 @@
         "isTileTool": true
       },
       {
+        "id": "Simulator",
+        "title": "EMG Simulator",
+        "isTileTool": true
+      },
+      {
         "id": "Table",
         "title": "Table",
         "isTileTool": true

--- a/curriculum/seeit/content.json
+++ b/curriculum/seeit/content.json
@@ -26,7 +26,8 @@
         "scalePlotOnValueChange": true
       },
       "simulator": {
-        "defaultSimulation": "terrarium"
+        "defaultSimulation": "terrarium",
+        "maxTiles": 1
       }
     },
     "learningLog": {


### PR DESCRIPTION
Now that it's possible to specify which simulation a unit cares about, it's better to be explicit about that than to rely on a default that might change at some point. This PR specifies the simulation for the brain and dfe units.

I also realized we hadn't specified only one tile for simluators in seeit, so this PR does that as well.