### PR TITLE
Add multi-link button to graph tile

### DIFF
--- a/curriculum/example-config-subtabs/content.json
+++ b/curriculum/example-config-subtabs/content.json
@@ -19,7 +19,11 @@
         "emptyPlotIsNumeric": true,
         "scalePlotOnValueChange": true,
         "defaultSeriesLegend": true,
-        "connectPointsByDefault": true
+        "connectPointsByDefault": true,
+        "tools": [
+          "link-tile",
+          "link-tile-multiple"
+        ]
       }
     },
     "navTabs": {


### PR DESCRIPTION
Configures the secondary "add data to graph" button, just for testing, in the example-config-subtabs unit.
This is part of PT-185968263
