### PR TITLE
186386300 Set moth unit so cells select cases

### DIFF
--- a/curriculum/moth/content.json
+++ b/curriculum/moth/content.json
@@ -24,6 +24,9 @@
     },
     "defaultDocumentType": "problem",
     "settings": {
+      "dataset": {
+        "cellsSelectCases": true
+      },
       "table": { "numFormat": ".2~f", "tools": ["link-tile", "link-graph", ["data-set-view", "DataCard"], "delete"]},
       "graph": {
         "defaultAxisLabels": {


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/186386300

This PR sets up the moth unit so that selecting cells in the table, datadeck, and graph (not yet implemented) will select the entire case the cell is a part of.