### PR TITLE
Add graph and diagram tiles to example-no-group-share config

### DIFF
--- a/curriculum/example-no-group-share/content.json
+++ b/curriculum/example-no-group-share/content.json
@@ -8,7 +8,24 @@
     "autoAssignStudentsToIndividualGroups": true,
     "disablePublish": true,
     "defaultDocumentType": "personal",
-    "settings": {"table": {"numFormat": ".2~f"}},
+    "settings": {
+      "table": {
+        "numFormat": ".2~f"
+      },
+      "graph": {
+        "defaultAxisLabels": {
+          "bottom": "x",
+          "left": "y"
+        },
+        "tools": [
+          "link-tile",
+          "link-tile-multiple"
+        ]
+      },
+      "diagram": {
+        "maxTiles": 1
+      }
+    },
     "navTabs": {
       "showNavPanel": false,
       "lazyLoadTabContents": true,
@@ -20,7 +37,51 @@
         }
       ]
     },
-    "toolbar": [{"id": "Text", "title": "Text", "isTileTool": true}, {"id": "Table", "title": "Table", "isTileTool": true}, {"id": "Drawing", "title": "Drawing", "isTileTool": true}, {"id": "delete", "title": "Delete", "iconId": "icon-delete-tool", "isTileTool": false}],
+    "toolbar": [
+      {
+        "id": "Text",
+        "title": "Text",
+        "isTileTool": true
+      },
+      {
+        "id": "Table",
+        "title": "Table",
+        "isTileTool": true
+      },
+      {
+        "id": "Drawing",
+        "title": "Drawing",
+        "isTileTool": true
+      },
+      {
+        "id": "Diagram",
+        "title": "Diagram",
+        "isTileTool": true
+      },
+      {
+        "id": "Graph",
+        "title": "XY Plot",
+        "isTileTool": true
+      },
+      {
+        "id": "undo",
+        "title": "Undo",
+        "iconId": "icon-undo-tool",
+        "isTileTool": false
+      },
+      {
+        "id": "redo",
+        "title": "Redo",
+        "iconId": "icon-redo-tool",
+        "isTileTool": false
+      },
+      {
+        "id": "delete",
+        "title": "Delete",
+        "iconId": "icon-delete-tool",
+        "isTileTool": false
+      }
+    ],
     "stamps": []
   },
   "sections": {


### PR DESCRIPTION
Based on the description in PT-186569276 we are going to use the `example-no-group-share` unit for testing the integration of the Diagram and XY Plot tiles.

This PR updates the unit configuration to include Diagram and XY Plot on the toolbar, as well as undo and redo.

It adds some useful configurations for those tiles, including the non-default XY Plot "Add data" toolbar button.

These changes, or something like them, are required in order to have a place to test out the linking in PT-186345541 .