### PR TITLE
186420492 Change Default Axis Labels for M2S

### DIFF
--- a/curriculum/m2s/content.json
+++ b/curriculum/m2s/content.json
@@ -80,8 +80,8 @@
       },
       "graph": {
         "defaultAxisLabels": {
-          "bottom": "x",
-          "left": "y"
+          "bottom": "axis label",
+          "left": "axis label"
         },
         "emptyPlotIsNumeric": true,
         "scalePlotOnValueChange": true


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/186420492

This PR makes the default xy plot axis labels for the m2s unit "axis label".