### PR TITLE
config sort-work to teacherOnly: false

### DIFF
--- a/curriculum/example-config-subtabs/content.json
+++ b/curriculum/example-config-subtabs/content.json
@@ -64,7 +64,7 @@
         {
           "tab": "sort-work",
           "label": "Sort Work",
-          "teacherOnly": true
+          "teacherOnly": false
         },
         {
           "tab": "my-work",


### PR DESCRIPTION
This enables Sort Work tab for students in the example-config-subtabs unit