### PR TITLE
Set MODS exemplars to be hidden (unshared) by default

### DIFF
--- a/curriculum/mods/content.json
+++ b/curriculum/mods/content.json
@@ -12,6 +12,7 @@
     "autoSectionProblemDocuments": true,
     "defaultDocumentType": "problem",
     "disablePublish": true,
+    "initiallyHideExemplars": true,
     "toolbar": [
       {
         "id": "select",


### PR DESCRIPTION
This setting, in conjunction with code updates, will activate the default-hidden behavior of exemplars for MODS.
It should not have any effect without the changes in the `exemplars-per-student` branch of CLUE, so it should be safe to merge at any time.
