### PR TITLE
CLUE 80 added question tile to qa unit

### DIFF
--- a/curriculum/qa/content.json
+++ b/curriculum/qa/content.json
@@ -54,6 +54,7 @@
       }
     },
     "toolbar": [
+      {"id": "Question", "title": "Question", "isTileTool": true},
       {"id": "Text", "title": "Text", "isTileTool": true},
       {"id": "Table", "title": "Table", "isTileTool": true},
       {"id": "DataCard", "title": "Data Card", "isTileTool": true},


### PR DESCRIPTION
[CLUE-80](https://concord-consortium.atlassian.net/browse/CLUE-80)

This adds the Question Tile toolbar to the `qa` unit so that we can check functionality for Question Tile in CLUE authoring.

[CLUE-80]: https://concord-consortium.atlassian.net/browse/CLUE-80?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ